### PR TITLE
Add API V1 controller and route

### DIFF
--- a/app/Http/Controllers/API/V1/ExampleController.php
+++ b/app/Http/Controllers/API/V1/ExampleController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers\API\V1;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+class ExampleController extends Controller
+{
+    public function __invoke(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Example response',
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,10 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\V1\ExampleController;
 
 Route::get('/', function () {
     return view('app');
 });
+
+Route::get('/api/v1/example', ExampleController::class);


### PR DESCRIPTION
## Summary
- add `ExampleController` in `API/V1` namespace returning JSON
- wire new `/api/v1/example` route to the namespaced controller

## Testing
- `composer test` *(fails: vendor directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68713b708e2c83229f0a21ad70aa740c