### PR TITLE
Add Swagger docs setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,19 @@ composer test
 - Custom JSON exception handler (`App\\Exceptions\\Handler`)
 - Authentication via Laravel Sanctum
 - Vue 3 frontend built with Vite
+
+## API documentation
+
+Swagger UI is available at `/api/docs` after running the Swagger generator. Endpoints can be documented using PHP attributes from `swagger-php`. Example:
+
+```php
+use OpenApi\Attributes as OA;
+
+#[OA\Get(path: '/api/v1/example', summary: 'Example endpoint')]
+public function __invoke(): JsonResponse
+{
+    return response()->json(['message' => 'Example response']);
+}
+```
+
+Run `php artisan l5-swagger:generate` to regenerate the OpenAPI spec.

--- a/app/Http/Controllers/API/V1/ExampleController.php
+++ b/app/Http/Controllers/API/V1/ExampleController.php
@@ -4,9 +4,24 @@ namespace App\Http\Controllers\API\V1;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Attributes as OA;
 
 class ExampleController extends Controller
 {
+    #[OA\Get(
+        path: '/api/v1/example',
+        summary: 'Example endpoint',
+        tags: ['Example'],
+        responses: [new OA\Response(
+            response: 200,
+            description: 'Successful response',
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'message', type: 'string', example: 'Example response'),
+                ]
+            )
+        )]
+    )]
     public function __invoke(): JsonResponse
     {
         return response()->json([

--- a/composer.json
+++ b/composer.json
@@ -1,77 +1,81 @@
 {
-    "$schema": "https://getcomposer.org/schema.json",
-    "name": "laravel/laravel",
-    "type": "project",
-    "description": "The skeleton application for the Laravel framework.",
-    "keywords": ["laravel", "framework"],
-    "license": "MIT",
-    "require": {
-        "php": "^8.2",
-        "laravel/framework": "^12.0",
-        "laravel/tinker": "^2.10.1",
-        "laravel/sanctum": "^4.0",
-        "spatie/laravel-query-builder": "^6.0",
-        "fruitcake/laravel-cors": "^3.0"
-    },
-    "require-dev": {
-        "fakerphp/faker": "^1.23",
-        "laravel/pint": "^1.13",
-        "laravel/sail": "^1.41",
-        "mockery/mockery": "^1.6",
-        "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^11.5.3"
-    },
-    "autoload": {
-        "psr-4": {
-            "App\\": "app/",
-            "Database\\Factories\\": "database/factories/",
-            "Database\\Seeders\\": "database/seeders/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests/"
-        }
-    },
-    "scripts": {
-        "post-autoload-dump": [
-            "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
-            "@php artisan package:discover --ansi"
-        ],
-        "post-update-cmd": [
-            "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
-        ],
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
-        "post-create-project-cmd": [
-            "@php artisan key:generate --ansi",
-            "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
-            "@php artisan migrate --graceful --ansi"
-        ],
-        "dev": [
-            "Composer\\Config::disableProcessTimeout",
-            "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
-        ],
-        "test": [
-            "@php artisan config:clear --ansi",
-            "@php artisan test"
-        ]
-    },
-    "extra": {
-        "laravel": {
-            "dont-discover": []
-        }
-    },
-    "config": {
-        "optimize-autoloader": true,
-        "preferred-install": "dist",
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "php-http/discovery": true
-        }
-    },
-    "minimum-stability": "stable",
-    "prefer-stable": true
+  "$schema": "https://getcomposer.org/schema.json",
+  "name": "laravel/laravel",
+  "type": "project",
+  "description": "The skeleton application for the Laravel framework.",
+  "keywords": [
+    "laravel",
+    "framework"
+  ],
+  "license": "MIT",
+  "require": {
+    "php": "^8.2",
+    "laravel/framework": "^12.0",
+    "laravel/tinker": "^2.10.1",
+    "laravel/sanctum": "^4.0",
+    "spatie/laravel-query-builder": "^6.0",
+    "fruitcake/laravel-cors": "^3.0",
+    "darkaonline/l5-swagger": "^10.0"
+  },
+  "require-dev": {
+    "fakerphp/faker": "^1.23",
+    "laravel/pint": "^1.13",
+    "laravel/sail": "^1.41",
+    "mockery/mockery": "^1.6",
+    "nunomaduro/collision": "^8.6",
+    "phpunit/phpunit": "^11.5.3"
+  },
+  "autoload": {
+    "psr-4": {
+      "App\\": "app/",
+      "Database\\Factories\\": "database/factories/",
+      "Database\\Seeders\\": "database/seeders/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "post-autoload-dump": [
+      "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
+      "@php artisan package:discover --ansi"
+    ],
+    "post-update-cmd": [
+      "@php artisan vendor:publish --tag=laravel-assets --ansi --force"
+    ],
+    "post-root-package-install": [
+      "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
+    ],
+    "post-create-project-cmd": [
+      "@php artisan key:generate --ansi",
+      "@php -r \"file_exists('database/database.sqlite') || touch('database/database.sqlite');\"",
+      "@php artisan migrate --graceful --ansi"
+    ],
+    "dev": [
+      "Composer\\Config::disableProcessTimeout",
+      "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
+    ],
+    "test": [
+      "@php artisan config:clear --ansi",
+      "@php artisan test"
+    ]
+  },
+  "extra": {
+    "laravel": {
+      "dont-discover": []
+    }
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "preferred-install": "dist",
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "php-http/discovery": true
+    }
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
 }

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    'default' => 'default',
+
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => env('L5_SWAGGER_API_TITLE', 'Morkovka 2.0'),
+                'version' => env('L5_SWAGGER_API_VERSION', 'v1'),
+            ],
+
+            'routes' => [
+                // Route used to serve the generated documentation.
+                'api' => 'api/docs.json',
+                // Route that displays Swagger UI.
+                'docs' => 'api/docs',
+                'middleware' => [
+                    'api' => [],
+                    'docs' => [],
+                    'asset' => [],
+                ],
+            ],
+
+            'paths' => [
+                'docs' => storage_path('api-docs'),
+                'annotations' => [
+                    base_path('app'),
+                    base_path('routes'),
+                ],
+            ],
+        ],
+    ],
+];

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -1,6 +1,9 @@
 <?php
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\API\V1\ExampleController;
 
 Route::get('/hello', function () {
     return response()->json(['message' => 'Hello from API v1']);
 });
+
+Route::get('/example', ExampleController::class);


### PR DESCRIPTION
## Summary
- add Swagger package dependency
- configure Swagger with OpenAPI 3 attributes
- document example endpoint via PHP attributes
- expose Swagger UI at `/api/docs`
- explain API docs in README

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_687168b5f64c83228606c4a872ff8060