### PR TITLE
Configure CORS for frontend domain

### DIFF
--- a/.env.ddev
+++ b/.env.ddev
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://morkovka.ddev.site:8000
+FRONTEND_URL=http://morkovka-frontend.ddev.site:5173
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ ddev artisan key:generate
 ddev artisan migrate --seed
 ```
 
+- If you modify `.env` later, run `ddev restart` to apply the changes.
+
 ---
 
 ## 🔗 Available Services

--- a/config/cors.php
+++ b/config/cors.php
@@ -17,7 +17,10 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [env('APP_URL', 'http://localhost')],
+    'allowed_origins' => [
+        env('APP_URL', 'http://localhost'),
+        env('FRONTEND_URL'),
+    ],
 
     'allowed_origins_patterns' => [],
 
@@ -27,7 +30,7 @@ return [
 
     'max_age' => 0,
 
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 
 ];
 


### PR DESCRIPTION
## Summary
- define `FRONTEND_URL` in `.env.ddev`
- allow `FRONTEND_URL` in the CORS config and enable credentials
- document the need to restart DDEV when the environment changes

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687269f14afc8322a6aaff4f163ca193