### PR TITLE
Fix README paths for front env

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is a Laravel API backend with a Vue 3 single-page application front
 ```bash
 # Copy environment files
 cp .env.ddev .env
-cp frontend/.env.ddev frontend/.env
+cp front/.env.ddev front/.env
 
 # Start services and install dependencies
 ddev start
@@ -62,7 +62,7 @@ Docs will be available at:
 
 ## 🎨 Frontend Setup
 
-Inside the `frontend/` directory:
+Inside the `front/` directory:
 
 ```bash
 ddev npm install

--- a/front/.env.ddev
+++ b/front/.env.ddev
@@ -1,0 +1,2 @@
+VITE_API_URL=https://morkovka.ddev.site:8443
+VITE_APP_NAME="${APP_NAME}"


### PR DESCRIPTION
## Summary
- fix README instructions for `front/`
- add `front/.env.ddev`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687269c6979c832283ccf80a3fd60748