### PR TITLE
Add demo UI page with shadcn-vue components

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -10,13 +10,17 @@
   },
   "dependencies": {
     "@radix-icons/vue": "^1.0.0",
+    "@tanstack/table-core": "^8.21.3",
+    "@tanstack/vue-table": "^8.21.3",
     "@vueuse/core": "^11.0.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "radix-vue": "^1.9.5",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
-    "vue": "^3.4.37"
+    "vue": "^3.4.37",
+    "vue-sonner": "^2.0.1",
+    "zod": "^4.0.5"
   },
   "devDependencies": {
     "@iconify-json/radix-icons": "^1.2.0",

--- a/front/src/components/DemoPage.vue
+++ b/front/src/components/DemoPage.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectItem } from '@/components/ui/select'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Button } from '@/components/ui/button'
+import { Icon } from "@iconify/vue"
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert'
+import { Dialog } from '@/components/ui/dialog'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell, TableCaption } from '@/components/ui/table'
+import { Toaster, toast } from '@/components/ui/sonner'
+import { useVueTable, getCoreRowModel, type ColumnDef } from '@tanstack/vue-table'
+import { z } from 'zod'
+import 'vue-sonner/lib/index.css'
+
+interface Person {
+  id: number
+  name: string
+  status: string
+}
+
+const columns: ColumnDef<Person>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Ім\'я' },
+  { accessorKey: 'status', header: 'Статус' },
+]
+
+const tableData = ref<Person[]>([
+  { id: 1, name: 'Борис', status: 'Активний' },
+  { id: 2, name: 'Ганна', status: 'Спить' },
+  { id: 3, name: 'Микита', status: 'На морі' },
+])
+
+const table = useVueTable({
+  data: tableData,
+  columns,
+  getCoreRowModel: getCoreRowModel(),
+})
+
+
+const form = ref({ name: '', email: '', agree: false, status: '' })
+const errors = ref<{ name?: string[]; email?: string[] }>({})
+
+const schema = z.object({
+  name: z.string().min(1, "Вкажіть ім'я"),
+  email: z.string().email('Невірна пошта'),
+})
+
+function submit() {
+  const result = schema.safeParse(form.value)
+  if (!result.success) {
+    errors.value = result.error.flatten().fieldErrors
+    toast('Форма має помилки, ай-яй-яй!')
+    return
+  }
+  errors.value = {}
+  toast('Форма відправлена! Але це ще нічого не означає.')
+}
+</script>
+
+<template>
+  <div class="dark p-8 space-y-8">
+    <h1 class="text-3xl font-bold text-center">Морква 2.0 — Презентація інтерфейсу</h1>
+    <p class="text-center text-muted-foreground">Що ми тут можемо, крім пельменів?</p>
+
+    <!-- Forms -->
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold">Форми: легше не буває</h2>
+      <Input placeholder="Просто input" />
+      <Textarea placeholder="А тут можна розписатися" />
+      <Select v-model="form.status">
+        <SelectItem value="one">Опція 1</SelectItem>
+        <SelectItem value="two">Опція 2</SelectItem>
+      </Select>
+      <div class="flex items-center space-x-2">
+        <Checkbox v-model="form.agree" />
+        <span>Погоджуюсь з тим, що це жарт</span>
+      </div>
+    </section>
+
+    <!-- Buttons -->
+    <section class="space-y-2">
+      <h2 class="text-xl font-semibold">Кнопки для натискання</h2>
+      <div class="flex gap-2">
+        <Button>Default</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="destructive">Destructive</Button>
+      </div>
+    </section>
+
+    <!-- Alert & Toast -->
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold">Алерти та тости</h2>
+      <Alert>
+        <Icon icon="radix-icons:info-circled" class="h-4 w-4" />
+        <div>
+          <AlertTitle>Ну і що тепер?</AlertTitle>
+          <AlertDescription>Невеличкий приклад алерту.</AlertDescription>
+        </div>
+      </Alert>
+      <Button @click="toast('Ви щойно натиснули. І що?')">Викликати toast</Button>
+    </section>
+
+    <!-- Dialog -->
+    <section class="space-y-2">
+      <h2 class="text-xl font-semibold">Модалка з гумором</h2>
+      <Dialog>
+        <template #trigger>
+          <Button>Відкрити модалку</Button>
+        </template>
+        <template #title>Привіт!</template>
+        <template #description>Ти відкрив модалку. Молодець!</template>
+      </Dialog>
+    </section>
+
+    <!-- Table -->
+    <section class="space-y-2">
+      <h2 class="text-xl font-semibold">Табличка скромних розмірів</h2>
+      <Table>
+        <TableHeader>
+          <TableRow v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
+            <TableHead v-for="header in headerGroup.headers" :key="header.id">
+              <span v-if="!header.isPlaceholder">
+                {{ header.column.columnDef.header }}
+              </span>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow v-for="row in table.getRowModel().rows" :key="row.id">
+            <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id">
+              {{ cell.getValue() }}
+            </TableCell>
+          </TableRow>
+        </TableBody>
+        <TableCaption>Суто фейкові дані</TableCaption>
+      </Table>
+    </section>
+
+    <!-- Form with Validation -->
+    <section class="space-y-4">
+      <h2 class="text-xl font-semibold">Форма з валідацією</h2>
+      <Input v-model="form.name" placeholder="Ім'я" />
+      <p v-if="errors.name" class="text-sm text-red-500">{{ errors.name[0] }}</p>
+      <Input v-model="form.email" placeholder="Пошта" />
+      <p v-if="errors.email" class="text-sm text-red-500">{{ errors.email[0] }}</p>
+      <Button @click="submit">Надіслати</Button>
+    </section>
+
+    <Toaster />
+  </div>
+</template>

--- a/front/src/components/ui/alert/Alert.vue
+++ b/front/src/components/ui/alert/Alert.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ variant?: 'default' | 'destructive'; class?: HTMLAttributes['class'] }>()
+</script>
+
+<template>
+  <div role="alert" :class="cn('relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+    props.variant === 'destructive' ? 'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive' : 'bg-background text-foreground', props.class)">
+    <slot />
+  </div>
+</template>

--- a/front/src/components/ui/alert/AlertDescription.vue
+++ b/front/src/components/ui/alert/AlertDescription.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <div :class="cn('text-sm [&_p]:leading-relaxed', props.class)"><slot /></div>
+</template>

--- a/front/src/components/ui/alert/AlertTitle.vue
+++ b/front/src/components/ui/alert/AlertTitle.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <h5 :class="cn('mb-1 font-medium leading-none tracking-tight', props.class)"><slot /></h5>
+</template>

--- a/front/src/components/ui/alert/index.ts
+++ b/front/src/components/ui/alert/index.ts
@@ -1,0 +1,3 @@
+export { default as Alert } from './Alert.vue'
+export { default as AlertTitle } from './AlertTitle.vue'
+export { default as AlertDescription } from './AlertDescription.vue'

--- a/front/src/components/ui/checkbox/Checkbox.vue
+++ b/front/src/components/ui/checkbox/Checkbox.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { CheckboxRoot, CheckboxIndicator } from 'radix-vue'
+import { Icon } from '@iconify/vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: HTMLAttributes['class']; modelValue?: boolean }>()
+const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>()
+</script>
+
+<template>
+  <CheckboxRoot
+    :checked="modelValue"
+    @update:checked="emit('update:modelValue', $event as boolean)"
+    v-bind="$attrs"
+    :class="cn('peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground', props.class)"
+  >
+    <CheckboxIndicator class="flex items-center justify-center text-current">
+      <Icon icon="radix-icons:check" class="h-4 w-4" />
+    </CheckboxIndicator>
+  </CheckboxRoot>
+</template>

--- a/front/src/components/ui/checkbox/index.ts
+++ b/front/src/components/ui/checkbox/index.ts
@@ -1,0 +1,1 @@
+export { default as Checkbox } from './Checkbox.vue'

--- a/front/src/components/ui/dialog/Dialog.vue
+++ b/front/src/components/ui/dialog/Dialog.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { DialogRoot, DialogTrigger, DialogPortal, DialogOverlay, DialogContent, DialogClose, DialogTitle, DialogDescription } from 'radix-vue'
+</script>
+
+<template>
+  <DialogRoot>
+    <DialogTrigger>
+      <slot name="trigger" />
+    </DialogTrigger>
+    <DialogPortal>
+      <DialogOverlay class="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogContent class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
+        <DialogTitle class="text-lg font-semibold leading-none tracking-tight">
+          <slot name="title" />
+        </DialogTitle>
+        <DialogDescription class="text-sm text-muted-foreground">
+          <slot name="description" />
+        </DialogDescription>
+        <slot />
+        <DialogClose class="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <span class="sr-only">Close</span>
+        </DialogClose>
+      </DialogContent>
+    </DialogPortal>
+  </DialogRoot>
+</template>

--- a/front/src/components/ui/dialog/index.ts
+++ b/front/src/components/ui/dialog/index.ts
@@ -1,0 +1,1 @@
+export { default as Dialog } from './Dialog.vue'

--- a/front/src/components/ui/input/Input.vue
+++ b/front/src/components/ui/input/Input.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: HTMLAttributes['class']; modelValue?: string | number }>()
+const emit = defineEmits<{ (e: 'update:modelValue', value: string | number): void }>()
+</script>
+
+<template>
+  <input
+    :value="modelValue"
+    @input="emit('update:modelValue', ($event.target as HTMLInputElement).value)"
+    v-bind="$attrs"
+    :class="cn('flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50', props.class)"
+  />
+</template>

--- a/front/src/components/ui/input/index.ts
+++ b/front/src/components/ui/input/index.ts
@@ -1,0 +1,1 @@
+export { default as Input } from './Input.vue'

--- a/front/src/components/ui/select/Select.vue
+++ b/front/src/components/ui/select/Select.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import {
+  SelectRoot,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectGroup,
+  SelectViewport
+} from 'radix-vue'
+import { Icon } from '@iconify/vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ modelValue?: string; class?: HTMLAttributes['class'] }>()
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
+</script>
+
+<template>
+  <SelectRoot :model-value="modelValue" @update:modelValue="emit('update:modelValue', $event as string)">
+    <SelectTrigger :class="cn('flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50', props.class)">
+      <SelectValue placeholder="Оберіть" />
+      <Icon icon="radix-icons:chevron-down" class="h-4 w-4 opacity-50" />
+    </SelectTrigger>
+    <SelectContent class="relative z-50 min-w-[8rem] overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md">
+      <SelectViewport class="p-1">
+        <SelectGroup>
+          <slot />
+        </SelectGroup>
+      </SelectViewport>
+    </SelectContent>
+  </SelectRoot>
+</template>

--- a/front/src/components/ui/select/SelectItem.vue
+++ b/front/src/components/ui/select/SelectItem.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const props = defineProps<{ value: string }>()
+import { SelectItem, SelectItemText, SelectItemIndicator } from 'radix-vue'
+import { Icon } from '@iconify/vue'
+</script>
+
+<template>
+  <SelectItem :value="props.value"
+    class="relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50">
+    <span class="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectItemIndicator>
+        <Icon icon="radix-icons:check" class="h-4 w-4" />
+      </SelectItemIndicator>
+    </span>
+    <SelectItemText>
+      <slot />
+    </SelectItemText>
+  </SelectItem>
+</template>

--- a/front/src/components/ui/select/index.ts
+++ b/front/src/components/ui/select/index.ts
@@ -1,0 +1,2 @@
+export { default as Select } from './Select.vue'
+export { default as SelectItem } from './SelectItem.vue'

--- a/front/src/components/ui/sonner/index.ts
+++ b/front/src/components/ui/sonner/index.ts
@@ -1,0 +1,1 @@
+export { Toaster, toast } from 'vue-sonner'

--- a/front/src/components/ui/table/Table.vue
+++ b/front/src/components/ui/table/Table.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <div class="relative w-full overflow-auto">
+    <table :class="cn('w-full caption-bottom text-sm', props.class)"><slot /></table>
+  </div>
+</template>

--- a/front/src/components/ui/table/TableBody.vue
+++ b/front/src/components/ui/table/TableBody.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <tbody :class="cn('[&_tr:last-child]:border-0', props.class)"><slot /></tbody>
+</template>

--- a/front/src/components/ui/table/TableCaption.vue
+++ b/front/src/components/ui/table/TableCaption.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <caption :class="cn('mt-4 text-sm text-muted-foreground', props.class)"><slot /></caption>
+</template>

--- a/front/src/components/ui/table/TableCell.vue
+++ b/front/src/components/ui/table/TableCell.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <td :class="cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', props.class)"><slot /></td>
+</template>

--- a/front/src/components/ui/table/TableHead.vue
+++ b/front/src/components/ui/table/TableHead.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <th :class="cn('h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0', props.class)"><slot /></th>
+</template>

--- a/front/src/components/ui/table/TableHeader.vue
+++ b/front/src/components/ui/table/TableHeader.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <thead :class="cn('[&_tr]:border-b', props.class)"><slot /></thead>
+</template>

--- a/front/src/components/ui/table/TableRow.vue
+++ b/front/src/components/ui/table/TableRow.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+const props = defineProps<{ class?: HTMLAttributes['class'] }>()
+</script>
+<template>
+  <tr :class="cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', props.class)"><slot /></tr>
+</template>

--- a/front/src/components/ui/table/index.ts
+++ b/front/src/components/ui/table/index.ts
@@ -1,0 +1,7 @@
+export { default as Table } from './Table.vue'
+export { default as TableHeader } from './TableHeader.vue'
+export { default as TableBody } from './TableBody.vue'
+export { default as TableRow } from './TableRow.vue'
+export { default as TableHead } from './TableHead.vue'
+export { default as TableCell } from './TableCell.vue'
+export { default as TableCaption } from './TableCaption.vue'

--- a/front/src/components/ui/textarea/Textarea.vue
+++ b/front/src/components/ui/textarea/Textarea.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import type { HTMLAttributes } from 'vue'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: HTMLAttributes['class']; modelValue?: string | number }>()
+const emit = defineEmits<{ (e: 'update:modelValue', value: string | number): void }>()
+</script>
+
+<template>
+  <textarea
+    :value="modelValue"
+    @input="emit('update:modelValue', ($event.target as HTMLTextAreaElement).value)"
+    v-bind="$attrs"
+    :class="cn('flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50', props.class)"
+  />
+</template>

--- a/front/src/components/ui/textarea/index.ts
+++ b/front/src/components/ui/textarea/index.ts
@@ -1,0 +1,1 @@
+export { default as Textarea } from './Textarea.vue'


### PR DESCRIPTION
## Summary
- add DemoPage.vue showcasing shadcn-vue components
- implement ui components (input, textarea, select, checkbox, alert, dialog, table)
- install vue-sonner and tanstack table

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687269bd7e848322ad4e95bf8d0c277f