### PR TITLE
Add Vue Query support with demo components

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
     "@radix-icons/vue": "^1.0.0",
     "@tanstack/table-core": "^8.21.3",
     "@tanstack/vue-table": "^8.21.3",
+    "@tanstack/vue-query": "^5.33.3",
     "@vueuse/core": "^11.0.3",
     "chart.js": "^4.5.0",
     "class-variance-authority": "^0.7.0",

--- a/front/src/components/ui/CarrotQueryExample.vue
+++ b/front/src/components/ui/CarrotQueryExample.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { useQuery } from '@tanstack/vue-query'
+
+interface Product {
+  id: number
+  name: string
+}
+
+const { data, error, isLoading } = useQuery<Product[]>({
+  queryKey: ['products'],
+  queryFn: async () => {
+    const res = await fetch('/api/products')
+    if (!res.ok) throw new Error('Failed to fetch')
+    return res.json() as Promise<Product[]>
+  },
+})
+</script>
+
+<template>
+  <div>
+    <div v-if="isLoading">Loading...</div>
+    <div v-else-if="error">Error: {{ (error as Error).message }}</div>
+    <ul v-else>
+      <li v-for="product in data" :key="product.id">{{ product.name }}</li>
+    </ul>
+  </div>
+</template>

--- a/front/src/components/ui/CarrotTable.vue
+++ b/front/src/components/ui/CarrotTable.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  useVueTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  type ColumnDef,
+  type SortingState,
+} from '@tanstack/vue-table'
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table'
+
+interface Item {
+  id: number
+  name: string
+  price: number
+}
+
+const data = ref<Item[]>([
+  { id: 1, name: 'Морква', price: 10 },
+  { id: 2, name: 'Буряк', price: 15 },
+  { id: 3, name: 'Капуста', price: 8 },
+])
+
+const columns: ColumnDef<Item>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Назва' },
+  { accessorKey: 'price', header: 'Ціна' },
+]
+
+const sorting = ref<SortingState>([])
+
+const table = useVueTable({
+  data,
+  columns,
+  state: {
+    get sorting() {
+      return sorting.value
+    },
+  },
+  onSortingChange: (updater) => {
+    sorting.value =
+      typeof updater === 'function' ? updater(sorting.value) : updater
+  },
+  getCoreRowModel: getCoreRowModel(),
+  getSortedRowModel: getSortedRowModel(),
+})
+</script>
+
+<template>
+  <Table>
+    <TableHeader>
+      <TableRow v-for="headerGroup in table.getHeaderGroups()" :key="headerGroup.id">
+        <TableHead
+          v-for="header in headerGroup.headers"
+          :key="header.id"
+          @click="header.column.getCanSort() && header.column.toggleSorting()"
+          class="cursor-pointer select-none"
+        >
+          <template v-if="!header.isPlaceholder">
+            {{ header.column.columnDef.header }}
+            <span v-if="header.column.getIsSorted() === 'asc'">▲</span>
+            <span v-if="header.column.getIsSorted() === 'desc'">▼</span>
+          </template>
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow v-for="row in table.getRowModel().rows" :key="row.id">
+        <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id">
+          {{ cell.getValue() }}
+        </TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</template>

--- a/front/src/main.ts
+++ b/front/src/main.ts
@@ -1,5 +1,9 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 import './assets/index.css'
+import { VueQueryPlugin } from '@tanstack/vue-query'
+import { vueQueryPluginOptions } from './plugins/vueQuery'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.use(VueQueryPlugin, vueQueryPluginOptions)
+app.mount('#app')

--- a/front/src/plugins/vueQuery.ts
+++ b/front/src/plugins/vueQuery.ts
@@ -1,0 +1,13 @@
+import { QueryClient, type VueQueryPluginOptions } from '@tanstack/vue-query'
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+})
+
+export const vueQueryPluginOptions: VueQueryPluginOptions = {
+  queryClient,
+}


### PR DESCRIPTION
## Summary
- install `@tanstack/vue-query`
- wire up Vue Query plugin
- add demo `CarrotTable` using `useVueTable` with sorting
- add demo `CarrotQueryExample` for fetching `/api/products`

## Testing
- `npm run build`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6874440eacd88322a9f3588d060da572