### PR TITLE
Add hero section and smooth UI transitions

### DIFF
--- a/front/src/assets/index.css
+++ b/front/src/assets/index.css
@@ -72,8 +72,11 @@
   * {
     @apply border-border;
   }
+  html {
+    @apply transition-colors duration-500;
+  }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground transition-colors duration-500;
   }
   a {
     @apply text-primary underline underline-offset-4 transition-colors hover:text-primary/80;
@@ -112,8 +115,4 @@
   table tbody tr:focus {
     @apply outline-none ring-2 ring-primary/50;
   }
-}
-
-body{
-  background-color: #f5f5f5;
 }

--- a/front/src/components/CarrotTableDemo.vue
+++ b/front/src/components/CarrotTableDemo.vue
@@ -137,7 +137,7 @@ function copyCell(value: unknown) {
           <TableRow
             v-for="row in table.getRowModel().rows"
             :key="row.id"
-            class="group hover:bg-muted hover:scale-[.99] transition-all"
+            class="group hover:bg-muted hover:scale-[.99] transition-all duration-200"
           >
             <TableCell
               v-for="cell in row.getVisibleCells()"

--- a/front/src/components/DemoPage.vue
+++ b/front/src/components/DemoPage.vue
@@ -153,17 +153,23 @@ onMounted(() => {
       >
         <Icon
           icon="radix-icons:moon"
-          class="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0"
+          class="h-5 w-5 rotate-0 scale-100 transition-all duration-300 ease-in-out dark:-rotate-90 dark:scale-0"
         />
         <Icon
           icon="radix-icons:sun"
-          class="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100"
+          class="absolute h-5 w-5 rotate-90 scale-0 transition-all duration-300 ease-in-out dark:rotate-0 dark:scale-100"
         />
         <span class="sr-only">Toggle theme</span>
       </Button>
 
       <!-- Main content (grid layout) -->
       <main class="space-y-8 md:mt-10">
+        <!-- Hero section -->
+        <section class="rounded-xl bg-gradient-to-br from-orange-100 to-orange-200 py-20 text-center shadow-md animate-in fade-in-0">
+          <h1 class="mb-4 text-5xl font-extrabold text-primary">Морква 2.0</h1>
+          <p class="text-lg text-muted-foreground">Сучасний UI на максималках</p>
+        </section>
+
         <!-- Заголовок -->
         <div class="text-center">
           <h1 class="text-3xl font-bold text-primary">Морква 2.0 — Презентація інтерфейсу</h1>

--- a/front/src/components/ui/dialog/Dialog.vue
+++ b/front/src/components/ui/dialog/Dialog.vue
@@ -8,8 +8,8 @@ import { DialogRoot, DialogTrigger, DialogPortal, DialogOverlay, DialogContent, 
       <slot name="trigger" />
     </DialogTrigger>
     <DialogPortal>
-      <DialogOverlay class="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-      <DialogContent class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
+      <DialogOverlay class="fixed inset-0 z-50 bg-black/80 transition-opacity duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogContent class="fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-300 transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
         <DialogTitle class="text-lg font-semibold leading-none tracking-tight">
           <slot name="title" />
         </DialogTitle>

--- a/front/src/components/ui/table/TableRow.vue
+++ b/front/src/components/ui/table/TableRow.vue
@@ -4,5 +4,5 @@ import { cn } from '@/lib/utils'
 const props = defineProps<{ class?: HTMLAttributes['class'] }>()
 </script>
 <template>
-  <tr :class="cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', props.class)"><slot /></tr>
+  <tr :class="cn('border-b transition-all duration-200 hover:bg-muted/50 data-[state=selected]:bg-muted', props.class)"><slot /></tr>
 </template>


### PR DESCRIPTION
## Summary
- tweak base styles for smooth theme transitions
- enhance row interactions for tables
- smooth dialog animations
- add hero section and micro interactions to demo page

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --dont-report-useless-tests`
- `npm install` in `front/`


------
https://chatgpt.com/codex/tasks/task_e_6874fc698b18832282b2bca48f03e319