### PR TITLE
Remove unused statuses variable

### DIFF
--- a/front/src/components/CarrotTableDemo.vue
+++ b/front/src/components/CarrotTableDemo.vue
@@ -110,7 +110,6 @@ interface Item {
 function generateData(count = 10000): Item[] {
   const names = ['Морква', 'Яблуко', 'Картопля', 'Банан', 'Гречка', 'Молоко', 'Сир', 'Апельсин', 'Огірок', 'Рис', 'Сметана', 'Груша', 'Перець', 'Манго', 'Пшоно']
   const categories = ['Овочі', 'Фрукти', 'Крупи', 'Молочне']
-  const statuses = ['active', 'low', 'none', 'archived'] as const
 
   return Array.from({ length: count }, (_, i) => {
     const name = names[i % names.length]


### PR DESCRIPTION
## Summary
- remove unused `statuses` array from CarrotTableDemo

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687556c849788322a2552ba5d5c559b5