### PR TITLE
Fix numeric pagination pageSize in demo

### DIFF
--- a/front/src/components/CarrotTableDemo.vue
+++ b/front/src/components/CarrotTableDemo.vue
@@ -8,7 +8,7 @@
       </div>
       <div>
         <label class="block text-sm font-medium mb-1">Категорія</label>
-        <Select v-model="categoryFilter" :modelValue="categoryFilter" @update:modelValue="categoryFilter = $event">
+        <Select :modelValue="categoryFilter" @update:modelValue="categoryFilter = $event">
           <SelectItem value="">Всі</SelectItem>
           <SelectItem value="Овочі">Овочі</SelectItem>
           <SelectItem value="Фрукти">Фрукти</SelectItem>
@@ -45,8 +45,8 @@
           <TableRow v-for="row in table.getRowModel().rows" :key="row.id" class="hover:bg-gray-50">
             <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id" class="px-2 py-1">
               <template v-if="cell.column.id === 'status'">
-                <span :class="getStatusColor(cell.getValue())" class="px-2 py-0.5 rounded text-xs font-medium">
-                  {{ getStatusLabel(cell.getValue()) }}
+                <span :class="getStatusColor(cell.getValue() as string)" class="px-2 py-0.5 rounded text-xs font-medium">
+                  {{ getStatusLabel(cell.getValue() as string) }}
                 </span>
               </template>
               <template v-else-if="cell.column.id === 'actions'">
@@ -65,7 +65,7 @@
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-2">
         <span class="text-sm">Показати:</span>
-        <Select v-model="pagination.pageSize" :modelValue="pagination.pageSize" @update:modelValue="pagination.pageSize = $event">
+        <Select :modelValue="String(pagination.pageSize)" @update:modelValue="pagination.pageSize = Number($event)">
           <SelectItem value="10">10</SelectItem>
           <SelectItem value="20">20</SelectItem>
           <SelectItem value="50">50</SelectItem>
@@ -110,7 +110,6 @@ interface Item {
 function generateData(count = 10000): Item[] {
   const names = ['Морква', 'Яблуко', 'Картопля', 'Банан', 'Гречка', 'Молоко', 'Сир', 'Апельсин', 'Огірок', 'Рис', 'Сметана', 'Груша', 'Перець', 'Манго', 'Пшоно']
   const categories = ['Овочі', 'Фрукти', 'Крупи', 'Молочне']
-  const statuses = ['active', 'low', 'none', 'archived'] as const
 
   return Array.from({ length: count }, (_, i) => {
     const name = names[i % names.length]
@@ -146,7 +145,7 @@ const filteredData = computed(() => {
 })
 
 const sorting = ref<SortingState>([])
-const pagination = ref({ pageIndex: 0, pageSize: '20' })
+const pagination = ref({ pageIndex: 0, pageSize: 20 })
 const columns: ColumnDef<Item>[] = [
   { accessorKey: 'id', header: 'ID' },
   { accessorKey: 'name', header: 'Назва' },


### PR DESCRIPTION
## Summary
- treat pagination pageSize as a number
- convert page size `<Select>` updates to numbers
- adjust template to satisfy TypeScript
- ensure build succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687556c22d0c8322916c6b40a4323bf3