### PR TITLE
Fix CI to run in backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
 
     strategy:
       fail-fast: true
@@ -35,13 +38,13 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+        run: composer install --prefer-dist --no-interaction --no-progress --working-dir=backend
 
       - name: Copy environment file
         run: cp .env.example .env
 
       - name: Generate app key
-        run: php artisan key:generate
+        run: php artisan key:generate --working-dir=backend
 
       - name: Execute tests
-        run: php artisan test
+        run: php artisan test --working-dir=backend


### PR DESCRIPTION
## Summary
- run GitHub Actions workflow from `backend`
- ensure Composer and Artisan commands use the backend directory

## Testing
- `pip install --quiet yamllint`
- `yamllint .github/workflows/tests.yml`


------
https://chatgpt.com/codex/tasks/task_e_68764584e6048322b87bd714dc0fcadc