### PR TITLE
Update env example with ddev settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,12 +1,76 @@
 # Example environment file
+# This file serves as a basic template.
 # Copy .env.ddev to .env for DDEV setup:
-
+#
 #   cp backend/.env.ddev backend/.env
-
+#
 #   cp frontend/.env.ddev frontend/.env
 
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://morkovka.ddev.site:8000
+FRONTEND_URL=http://morkovka-frontend.ddev.site:5173
+
+APP_LOCALE=en
+APP_FALLBACK_LOCALE=en
+APP_FAKER_LOCALE=en_US
+
+APP_MAINTENANCE_DRIVER=file
+# APP_MAINTENANCE_STORE=database
+
+PHP_CLI_SERVER_WORKERS=4
+
+BCRYPT_ROUNDS=12
+
+LOG_CHANNEL=stack
+LOG_STACK=single
+LOG_DEPRECATIONS_CHANNEL=null
+LOG_LEVEL=debug
+
 DB_CONNECTION=pgsql
+DB_HOST=db
 DB_PORT=5432
 DB_DATABASE=morkovka
 DB_USERNAME=postgres
 DB_PASSWORD=secret
+
+SESSION_DRIVER=array
+SESSION_LIFETIME=120
+SESSION_ENCRYPT=false
+SESSION_PATH=/
+SESSION_DOMAIN=null
+
+BROADCAST_CONNECTION=log
+FILESYSTEM_DISK=local
+QUEUE_CONNECTION=database
+
+CACHE_STORE=database
+# CACHE_PREFIX=
+
+MEMCACHED_HOST=127.0.0.1
+
+REDIS_CLIENT=phpredis
+REDIS_HOST=127.0.0.1
+REDIS_PASSWORD=null
+REDIS_PORT=6379
+
+MAIL_MAILER=log
+MAIL_SCHEME=null
+MAIL_HOST=127.0.0.1
+MAIL_PORT=2525
+MAIL_USERNAME=null
+MAIL_PASSWORD=null
+MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_FROM_NAME="${APP_NAME}"
+
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=us-east-1
+AWS_BUCKET=
+AWS_USE_PATH_STYLE_ENDPOINT=false
+
+SANCTUM_STATEFUL_DOMAINS=morkovka-frontend.ddev.site:5173
+
+VITE_APP_NAME="${APP_NAME}"


### PR DESCRIPTION
## Summary
- extend backend/.env.example with variables from .env.ddev
- note that the file is a basic template

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68764580b35c83229c74859fa6e76f01